### PR TITLE
Use the negotiated algorithm for key verification

### DIFF
--- a/src/conn/conn_test.rs
+++ b/src/conn/conn_test.rs
@@ -2221,8 +2221,10 @@ async fn test_protocol_version_validation() -> Result<()> {
                             elliptic_curve_type: EllipticCurveType::NamedCurve,
                             named_curve: NamedCurve::X25519,
                             public_key: local_keypair.public_key.clone(),
-                            hash_algorithm: HashAlgorithm::Sha256,
-                            signature_algorithm: SignatureAlgorithm::Ecdsa,
+                            algorithm: SignatureHashAlgorithm {
+                                hash: HashAlgorithm::Sha256,
+                                signature: SignatureAlgorithm::Ecdsa,
+                            },
                             signature: vec![0; 64],
                         },
                     ));

--- a/src/crypto/crypto_test.rs
+++ b/src/crypto/crypto_test.rs
@@ -183,6 +183,10 @@ fn test_certificate_verify() -> Result<()> {
         generate_certificate_verify(&plain_text, &certificate_ecdsa256.private_key)?;
     verify_certificate_verify(
         &plain_text,
+        &SignatureHashAlgorithm {
+            hash: HashAlgorithm::Sha256,
+            signature: SignatureAlgorithm::Ecdsa,
+        },
         &cert_verify_ecdsa256,
         &certificate_ecdsa256
             .certificate
@@ -200,6 +204,10 @@ fn test_certificate_verify() -> Result<()> {
         generate_certificate_verify(&plain_text, &certificate_ed25519.private_key)?;
     verify_certificate_verify(
         &plain_text,
+        &SignatureHashAlgorithm {
+            hash: HashAlgorithm::Sha256,
+            signature: SignatureAlgorithm::Ed25519,
+        },
         &cert_verify_ed25519,
         &certificate_ed25519
             .certificate

--- a/src/flight/flight4.rs
+++ b/src/flight/flight4.rs
@@ -194,7 +194,7 @@ impl Flight for Flight4 {
             // Verify that the pair of hash algorithm and signature is listed.
             let mut valid_signature_scheme = false;
             for ss in &cfg.local_signature_schemes {
-                if ss.hash == h.hash_algorithm && ss.signature == h.signature_algorithm {
+                if ss.hash == h.algorithm.hash && ss.signature == h.algorithm.signature {
                     valid_signature_scheme = true;
                     break;
                 }
@@ -211,7 +211,8 @@ impl Flight for Flight4 {
 
             if let Err(err) = verify_certificate_verify(
                 &plain_text,
-                /*h.hash_algorithm,*/ &h.signature,
+                &h.algorithm,
+                &h.signature,
                 &state.peer_certificates,
             ) {
                 return Err((
@@ -640,8 +641,10 @@ impl Flight for Flight4 {
                                 elliptic_curve_type: EllipticCurveType::NamedCurve,
                                 named_curve: state.named_curve,
                                 public_key: local_keypair.public_key.clone(),
-                                hash_algorithm: signature_hash_algo.hash,
-                                signature_algorithm: signature_hash_algo.signature,
+                                algorithm: SignatureHashAlgorithm {
+                                    hash: signature_hash_algo.hash,
+                                    signature: signature_hash_algo.signature,
+                                },
                                 signature: state.local_key_signature.clone(),
                             },
                         ))),
@@ -686,8 +689,10 @@ impl Flight for Flight4 {
                             elliptic_curve_type: EllipticCurveType::Unsupported,
                             named_curve: NamedCurve::Unsupported,
                             public_key: vec![],
-                            hash_algorithm: HashAlgorithm::Unsupported,
-                            signature_algorithm: SignatureAlgorithm::Unsupported,
+                            algorithm: SignatureHashAlgorithm {
+                                hash: HashAlgorithm::Unsupported,
+                                signature: SignatureAlgorithm::Unsupported,
+                            },
                             signature: vec![],
                         },
                     ))),

--- a/src/handshake/handshake_message_certificate_verify.rs
+++ b/src/handshake/handshake_message_certificate_verify.rs
@@ -9,8 +9,7 @@ use std::io::{Read, Write};
 
 #[derive(Clone, Debug, PartialEq)]
 pub struct HandshakeMessageCertificateVerify {
-    pub(crate) hash_algorithm: HashAlgorithm,
-    pub(crate) signature_algorithm: SignatureAlgorithm,
+    pub(crate) algorithm: SignatureHashAlgorithm,
     pub(crate) signature: Vec<u8>,
 }
 
@@ -26,8 +25,8 @@ impl HandshakeMessageCertificateVerify {
     }
 
     pub fn marshal<W: Write>(&self, writer: &mut W) -> Result<()> {
-        writer.write_u8(self.hash_algorithm as u8)?;
-        writer.write_u8(self.signature_algorithm as u8)?;
+        writer.write_u8(self.algorithm.hash as u8)?;
+        writer.write_u8(self.algorithm.signature as u8)?;
         writer.write_u16::<BigEndian>(self.signature.len() as u16)?;
         writer.write_all(&self.signature)?;
 
@@ -42,8 +41,10 @@ impl HandshakeMessageCertificateVerify {
         reader.read_exact(&mut signature)?;
 
         Ok(HandshakeMessageCertificateVerify {
-            hash_algorithm,
-            signature_algorithm,
+            algorithm: SignatureHashAlgorithm {
+                hash: hash_algorithm,
+                signature: signature_algorithm,
+            },
             signature,
         })
     }

--- a/src/handshake/handshake_message_certificate_verify/handshake_message_certificate_verify_test.rs
+++ b/src/handshake/handshake_message_certificate_verify/handshake_message_certificate_verify_test.rs
@@ -12,8 +12,10 @@ fn test_handshake_message_certificate_request() -> Result<()> {
         0x00, 0x2c, 0xe5, 0x94, 0xbb, 0x03, 0x0e, 0xf1, 0xcb, 0x28, 0x22, 0x33, 0x23, 0x88, 0xad,
     ];
     let parsed_certificate_verify = HandshakeMessageCertificateVerify {
-        hash_algorithm: raw_certificate_verify[0].into(),
-        signature_algorithm: raw_certificate_verify[1].into(),
+        algorithm: SignatureHashAlgorithm {
+            hash: raw_certificate_verify[0].into(),
+            signature: raw_certificate_verify[1].into(),
+        },
         signature: raw_certificate_verify[4..].to_vec(),
     };
 

--- a/src/handshake/handshake_message_server_key_exchange.rs
+++ b/src/handshake/handshake_message_server_key_exchange.rs
@@ -17,8 +17,7 @@ pub struct HandshakeMessageServerKeyExchange {
     pub(crate) elliptic_curve_type: EllipticCurveType,
     pub(crate) named_curve: NamedCurve,
     pub(crate) public_key: Vec<u8>,
-    pub(crate) hash_algorithm: HashAlgorithm,
-    pub(crate) signature_algorithm: SignatureAlgorithm,
+    pub(crate) algorithm: SignatureHashAlgorithm,
     pub(crate) signature: Vec<u8>,
 }
 
@@ -48,8 +47,8 @@ impl HandshakeMessageServerKeyExchange {
         writer.write_u8(self.public_key.len() as u8)?;
         writer.write_all(&self.public_key)?;
 
-        writer.write_u8(self.hash_algorithm as u8)?;
-        writer.write_u8(self.signature_algorithm as u8)?;
+        writer.write_u8(self.algorithm.hash as u8)?;
+        writer.write_u8(self.algorithm.signature as u8)?;
 
         writer.write_u16::<BigEndian>(self.signature.len() as u16)?;
         writer.write_all(&self.signature)?;
@@ -70,8 +69,10 @@ impl HandshakeMessageServerKeyExchange {
                 elliptic_curve_type: EllipticCurveType::Unsupported,
                 named_curve: NamedCurve::Unsupported,
                 public_key: vec![],
-                hash_algorithm: HashAlgorithm::Unsupported,
-                signature_algorithm: SignatureAlgorithm::Unsupported,
+                algorithm: SignatureHashAlgorithm {
+                    hash: HashAlgorithm::Unsupported,
+                    signature: SignatureAlgorithm::Unsupported,
+                },
                 signature: vec![],
             });
         }
@@ -121,8 +122,10 @@ impl HandshakeMessageServerKeyExchange {
             elliptic_curve_type,
             named_curve,
             public_key,
-            hash_algorithm,
-            signature_algorithm,
+            algorithm: SignatureHashAlgorithm {
+                hash: hash_algorithm,
+                signature: signature_algorithm,
+            },
             signature,
         })
     }

--- a/src/handshake/handshake_message_server_key_exchange/handshake_message_server_key_exchange_test.rs
+++ b/src/handshake/handshake_message_server_key_exchange/handshake_message_server_key_exchange_test.rs
@@ -21,8 +21,11 @@ fn test_handshake_message_server_key_exchange() -> Result<()> {
         elliptic_curve_type: EllipticCurveType::NamedCurve,
         named_curve: NamedCurve::X25519,
         public_key: raw_server_key_exchange[4..69].to_vec(),
-        hash_algorithm: HashAlgorithm::Sha1,
-        signature_algorithm: SignatureAlgorithm::Ecdsa,
+        algorithm: SignatureHashAlgorithm {
+            hash: HashAlgorithm::Sha1,
+            signature: SignatureAlgorithm::Ecdsa,
+        },
+
         signature: raw_server_key_exchange[73..144].to_vec(),
     };
 


### PR DESCRIPTION
As intimated in https://github.com/webrtc-rs/webrtc/issues/184, we were using the signature algorithm on the supplied certificate to decision on key verification.

That is probably incorrect. In this pull request I

1) Bundle up the hash/signature algorithm where we use both of them
2) Supply this bundled hash/signature to the key verification function
3) Use this to determine what verification method we should be using

I have tested this locally with

1) Chrome egest
2) Chrome ingest
3) Firefox egest
4) Firefox ingest
5) Millicast egest

And the right decision is being made.

There is a chance that this also fixes #15, but this is only a hypothesis and isn't a guarantee.