### PR TITLE
Backport buffer limit fix from Pion

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -144,6 +144,11 @@ pub enum Error {
     #[error("Alert is Fatal or Close Notify")]
     ErrAlertFatalOrClose,
 
+    #[error(
+        "Fragment buffer overflow. New size {new_size} is greater than specified max {max_size}"
+    )]
+    ErrFragmentBufferOverflow { new_size: usize, max_size: usize },
+
     #[error("{0}")]
     Io(#[source] IoError),
     #[error("{0}")]

--- a/src/fragment_buffer/fragment_buffer_test.rs
+++ b/src/fragment_buffer/fragment_buffer_test.rs
@@ -143,3 +143,23 @@ fn test_fragment_buffer() -> Result<()> {
 
     Ok(())
 }
+
+#[test]
+fn test_fragment_buffer_overflow() -> Result<()> {
+    let mut fragment_buffer = FragmentBuffer::new();
+
+    fragment_buffer.push(&[
+        0x16, 0xfe, 0xff, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x0F, 0x03, 0x00,
+        0x00, 0x03, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x03, 0xfe, 0xff, 0x00,
+    ])?;
+
+    let big_buffer = vec![0; 2_000_000];
+    let result = fragment_buffer.push(&big_buffer);
+
+    assert!(
+        result.is_err(),
+        "Pushing a buffer of size 2MB should have caused FragmentBuffer::push to return an error"
+    );
+
+    Ok(())
+}


### PR DESCRIPTION
This commit fixes a security issue that was discovered and fixed in Pion
by limiting the max size of the fragment buffer. Without it an attacker
could cause unbounded memory growth.

Security advisory: https://github.com/pion/dtls/security/advisories/GHSA-cx94-mrg9-rq4j


This was fixed in https://github.com/pion/dtls/pull/461 in Pion