### PR TITLE
remove use of lazy_static

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,6 @@ repository = "https://github.com/webrtc-rs/dtls"
 [dependencies]
 util = { package = "webrtc-util", version = "0.5.3", default-features = false, features = ["conn"] }
 byteorder = "1.4.3"
-lazy_static = "1.4.0"
 rand_core = "0.6.3"
 elliptic-curve = { version = "0.11.12", features = ["default", "ecdh"] }
 p256 = { version = "0.10", features=["default", "ecdh", "ecdsa"] }

--- a/src/conn/conn_test.rs
+++ b/src/conn/conn_test.rs
@@ -479,7 +479,7 @@ async fn test_export_keying_material() -> Result<()> {
         assert!(false, "expect error but export_keying_material returns OK");
     }
 
-    for (k, _v) in INVALID_KEYING_LABELS.iter() {
+    for k in INVALID_KEYING_LABELS.iter() {
         let state = c.connection_state().await;
         if let Err(err) = state.export_keying_material(k, &[], 0).await {
             assert!(

--- a/src/conn/mod.rs
+++ b/src/conn/mod.rs
@@ -28,7 +28,6 @@ use util::{replay_detector::*, Conn};
 
 use async_trait::async_trait;
 use log::*;
-use std::collections::HashMap;
 use std::io::{BufReader, BufWriter};
 use std::marker::{Send, Sync};
 use std::net::SocketAddr;
@@ -44,16 +43,12 @@ pub(crate) const INBOUND_BUFFER_SIZE: usize = 8192;
 // Default replay protection window is specified by RFC 6347 Section 4.1.2.6
 pub(crate) const DEFAULT_REPLAY_PROTECTION_WINDOW: usize = 64;
 
-lazy_static! {
-    pub static ref INVALID_KEYING_LABELS: HashMap<&'static str, bool> = {
-        let mut map = HashMap::new();
-        map.insert("client finished", true);
-        map.insert("server finished", true);
-        map.insert("master secret", true);
-        map.insert("key expansion", true);
-        map
-    };
-}
+pub static INVALID_KEYING_LABELS: &[&str] = &[
+    "client finished",
+    "server finished",
+    "master secret",
+    "key expansion",
+];
 
 type PacketSendRequest = (Vec<Packet>, Option<mpsc::Sender<Result<()>>>);
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,9 +2,6 @@
 #![allow(dead_code)]
 
 #[macro_use]
-extern crate lazy_static;
-
-#[macro_use]
 extern crate serde_derive;
 
 pub mod alert;

--- a/src/state.rs
+++ b/src/state.rs
@@ -266,7 +266,7 @@ impl KeyingMaterialExporter for State {
             return Err(HandshakeInProgress);
         } else if !context.is_empty() {
             return Err(ContextUnsupported);
-        } else if INVALID_KEYING_LABELS.contains_key(label) {
+        } else if INVALID_KEYING_LABELS.contains(&label) {
             return Err(ReservedExportKeyingMaterial);
         }
 


### PR DESCRIPTION
Seemed overkill to include lazy_static for a single, short lookup map. Hence replaced the implementation with a static array. Guessing its about the same performance wise, or faster, for short lists like these.